### PR TITLE
Update side menu responsiveness

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,10 +30,12 @@
                             "src/assets"
                         ],
                         "styles": [
-                            "node_modules/bootstrap/scss/bootstrap.scss",
+                            "node_modules/bootstrap/dist/css/bootstrap.min.css",
                             "src/styles.scss"
                         ],
                         "scripts": [
+                            "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+
                         ]
                     },
                     "configurations": {
@@ -94,9 +96,12 @@
                             "src/assets"
                         ],
                         "styles": [
-                            "src/styles.scss"
+                              "node_modules/bootstrap/dist/css/bootstrap.min.css",
+  "src/styles.scss"
+                       
                         ],
-                        "scripts": []
+                        "scripts": ["node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+]
                     }
                 }
             }

--- a/lib/angular.json
+++ b/lib/angular.json
@@ -30,9 +30,11 @@
               "src/assets"
             ],
             "styles": [
+            "node_modules/bootstrap/dist/css/bootstrap.min.css",
+
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": ["node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"]
           },
           "configurations": {
             "production": {
@@ -93,9 +95,10 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.scss"
+              "src/styles.scss",
+              "node_modules/bootstrap/dist/css/bootstrap.min.css"
             ],
-            "scripts": []
+            "scripts": ["node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"]
           }
         }
       }

--- a/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.html
+++ b/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.html
@@ -1,39 +1,32 @@
-<div class="row">
+
+<div class="row mt-3">
   <div class="d-grid d-lg-flex m-auto gap-lg-3">
     <div class="col-md-2 m-md-auto">
-      <select
-        class="form-select p-2 mb-3 mt-3 border-secondary-subtle">
-        <option selected>Get</option>
-        <option value="1">Post</option>
-        <option value="2">Put</option>
-        <option value="3">Patch</option>
-        <option value="4">Delete</option>
-        <option value="5">Copy</option>
-        <option value="6">Link</option>
-      </select>
+<select
+  class="form-select p-2 mb-3 mt-3 border-secondary-subtle fw-bold"
+  [ngClass]="getMethodClass(selectedMethod)"
+  [(ngModel)]="selectedMethod">
+  <option *ngFor="let method of methods" [value]="method">{{ method }}</option>
+</select>
     </div>
     <div class="col-md-8 m-md-auto">
-      <input type="text" class="form-control mb-3 mt-3 p-2"
+      <input type="text" class="form-control mb-3 mt-3 p-2  "
         placeholder="Enter request url">
     </div>
-    <div class="row gap-sm-4 gap-md-0 text-center">
+
+     <div class="row gap-sm-4 gap-md-0 text-center">
       <div class="col-sm-10 col-lg-12 m-auto">
         <div class="btn-group w-100">
-          <button class="btn btn-primary px-4 py-2 w-100" type="button">
+       <button
+            class="btn send-btn dropdown-toggle text-white"
+            type="button"
+            data-bs-toggle="dropdown"
+            aria-expanded="false">
             Send
           </button>
-          <button
-            appDropDown #myDropDown="appDropDown"
-            type="button"
-            class="btn btn-sm btn-primary dropdown-toggle" type="button"
-            data-toggle="dropdown">
-            <span class="sr-only"></span>
-          </button>
-          <div
-            [ngClass]="{'show':myDropDown.isOpen}"
-            class="dropdown-menu mt-5 px-2">
-            Send And Download
-          </div>
+        <ul class="dropdown-menu">
+            <li><button class="dropdown-item text-dark" type="button">Send And Download</button></li>
+          </ul>
         </div>
       </div>
     </div>

--- a/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.scss
+++ b/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.scss
@@ -1,0 +1,36 @@
+.form-select.text-success {
+  color: green;
+}
+.form-select.text-primary {
+  color: #0d6efd;
+}
+.form-select.text-danger {
+  color: #dc3545;
+}
+.form-select.text-warning {
+  color: #ffc107;
+}
+.form-select.text-info {
+  color: #0dcaf0;
+}
+
+
+.send-btn{
+background-image:linear-gradient(to top, #EB3449, #F3482D);
+}
+.send-btn:focus{
+  
+background-image:linear-gradient(to top, #EB3449, #F3482D);
+
+}
+
+
+.form-control:focus {
+  outline: none; 
+  box-shadow: 0 0 0 3px #f3482d; 
+  border: 1px solid #f3482d; }
+  
+.form-select:focus {
+  outline: none; 
+  box-shadow: 0 0 0 3px #f3482d; 
+  border: 1px solid #f3482d; }

--- a/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.scss
+++ b/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.scss
@@ -1,18 +1,18 @@
-.form-select.text-success {
-  color: green;
-}
-.form-select.text-primary {
-  color: #0d6efd;
-}
-.form-select.text-danger {
-  color: #dc3545;
-}
-.form-select.text-warning {
-  color: #ffc107;
-}
-.form-select.text-info {
-  color: #0dcaf0;
-}
+// .form-select.text-success {
+//   color: green;
+// }
+// .form-select.text-primary {
+//   color: #0d6efd;
+// }
+// .form-select.text-danger {
+//   color: #dc3545;
+// }
+// .form-select.text-warning {
+//   color: #ffc107;
+// }
+// .form-select.text-info {
+//   color: #0dcaf0;
+// }
 
 
 .send-btn{
@@ -34,3 +34,23 @@ background-image:linear-gradient(to top, #EB3449, #F3482D);
   outline: none; 
   box-shadow: 0 0 0 3px #f3482d; 
   border: 1px solid #f3482d; }
+
+
+.text-success {
+  color: green !important;
+}
+.text-warning {
+  color: orange !important;
+}
+.text-primary {
+  color: blue !important;
+}
+.text-info {
+  color: deepskyblue !important;
+}
+.text-danger {
+  color: red !important;
+}
+.text-secondary {
+  color: gray !important;
+}

--- a/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.ts
+++ b/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.ts
@@ -23,20 +23,22 @@ export class FormPaneComponent  {
 selectedMethod: string = 'GET';
 
 getMethodClass(method: string): string {
-  switch (method.toLowerCase()) {
-    case 'get':
-      return 'text-success'; // أخضر
-    case 'post':
-      return 'text-primary'; // أزرق
-    case 'put':
-      return 'text-warning'; // أصفر
-    case 'patch':
-      return 'text-info'; // سماوي
-    case 'delete':
-      return 'text-danger'; // أحمر
+  switch (method.toUpperCase()) {
+    case 'GET':
+      return 'text-success';    
+    case 'POST':
+      return 'text-warning';    
+    case 'PUT':
+      return 'text-primary';    
+    case 'PATCH':
+      return 'text-info';      
+    case 'DELETE':
+      return 'text-danger';     
     default:
-      return 'text-secondary'; // رمادي
+      return 'text-secondary'; 
   }
 }
+
+
 
 }

--- a/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.ts
+++ b/lib/src/test-behaviours-ui/common/components/form-pane/form-pane.component.ts
@@ -19,4 +19,24 @@ export class FormPaneComponent  {
       }
     });
   }
+  methods: string[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'COPY', 'LINK'];
+selectedMethod: string = 'GET';
+
+getMethodClass(method: string): string {
+  switch (method.toLowerCase()) {
+    case 'get':
+      return 'text-success'; // أخضر
+    case 'post':
+      return 'text-primary'; // أزرق
+    case 'put':
+      return 'text-warning'; // أصفر
+    case 'patch':
+      return 'text-info'; // سماوي
+    case 'delete':
+      return 'text-danger'; // أحمر
+    default:
+      return 'text-secondary'; // رمادي
+  }
+}
+
 }

--- a/lib/src/test-behaviours-ui/common/components/json-text-area/json-text-area.component.html
+++ b/lib/src/test-behaviours-ui/common/components/json-text-area/json-text-area.component.html
@@ -1,8 +1,8 @@
 <div class="row mx-4">
   <div class="col-12">
-    <div class="editor-container">
-      <div id="multilineEditor">{{multilineText}}</div>
-      <div id="readonlyEditor">{{readonlyText}}</div>
+    <div class="editor__container">
+      <div id="multilineEditor" class="editor__container-multilineEditor" >{{multilineText}}</div>
+      <div id="readonlyEditor" class="editor__container-readonlyEditor">{{readonlyText}}</div>
     </div>
   </div>
 </div>

--- a/lib/src/test-behaviours-ui/common/components/json-text-area/json-text-area.component.html
+++ b/lib/src/test-behaviours-ui/common/components/json-text-area/json-text-area.component.html
@@ -1,8 +1,8 @@
 <div class="row mx-4">
   <div class="col-12">
     <div class="editor-container">
-      <div id="multilineEditor" class="mb-5" style="height: 300px; width: 100%;">{{multilineText}}</div>
-      <div id="readonlyEditor" style="height: 300px; width: 100%;">{{readonlyText}}</div>
+      <div id="multilineEditor">{{multilineText}}</div>
+      <div id="readonlyEditor">{{readonlyText}}</div>
     </div>
   </div>
 </div>

--- a/lib/src/test-behaviours-ui/common/components/json-text-area/json-text-area.component.scss
+++ b/lib/src/test-behaviours-ui/common/components/json-text-area/json-text-area.component.scss
@@ -1,0 +1,13 @@
+#readonlyEditor{
+    width: 100%;
+    height: 300px;
+      border: rgb(138, 134, 134) solid;
+}
+#multilineEditor{
+    width: 100%;
+    height: 300px;
+    margin-bottom: 50px;
+      border: rgb(138, 134, 134) solid;
+}
+
+

--- a/lib/src/test-behaviours-ui/common/components/json-text-area/json-text-area.component.scss
+++ b/lib/src/test-behaviours-ui/common/components/json-text-area/json-text-area.component.scss
@@ -1,9 +1,9 @@
-#readonlyEditor{
+.editor__container-multilineEditor{
     width: 100%;
     height: 300px;
       border: rgb(138, 134, 134) solid;
 }
-#multilineEditor{
+.editor__container-readonlyEditor{
     width: 100%;
     height: 300px;
     margin-bottom: 50px;

--- a/lib/src/test-behaviours-ui/common/components/layout/layout.component.html
+++ b/lib/src/test-behaviours-ui/common/components/layout/layout.component.html
@@ -1,24 +1,11 @@
-
-<div class="container-fluid pt-5 ">
-  
-  <button
-    class="btn btn-outline-dark d-md-none m-3"
-    type="button"
-    data-bs-toggle="offcanvas"
-    data-bs-target="#sideMenu"
-    aria-controls="sideMenu"
-  >
-    ☰
-  </button>
-
+<div class="container-fluid pt-5">
   <div
-    class="offcanvas offcanvas-start d-md-none"
+    class="offcanvas offcanvas-start d-lg-none"
     tabindex="-1"
     id="sideMenu"
     aria-labelledby="sideMenuLabel"
   >
     <div class="offcanvas-header">
-
       <button
         type="button"
         class="btn-close"
@@ -26,18 +13,18 @@
         aria-label="Close"
       ></button>
     </div>
-    <div class="offcanvas-body ">
+    <div class="offcanvas-body">
       <app-side-menu [requests]="requests"></app-side-menu>
     </div>
   </div>
 
   <div class="row">
-
-    <div class="col-md-2 d-none d-md-block border-end min-vh-100 pt-5">
+   
+    <div class="col-lg-2 d-none d-lg-block border-end min-vh-100 pt-5">
       <app-side-menu [requests]="requests"></app-side-menu>
     </div>
 
-  <div class="col-12 col-md-10 pt-3">
+    <div class="col-12 col-lg-10 pt-1">
       <app-form-pane></app-form-pane>
     </div>
   </div>

--- a/lib/src/test-behaviours-ui/common/components/layout/layout.component.html
+++ b/lib/src/test-behaviours-ui/common/components/layout/layout.component.html
@@ -1,9 +1,43 @@
-<div class="container-fluid">
-  <div class="row">
-    <div class="col-2 fixed-sidebar">
+
+<div class="container-fluid pt-5 ">
+  
+  <button
+    class="btn btn-outline-dark d-md-none m-3"
+    type="button"
+    data-bs-toggle="offcanvas"
+    data-bs-target="#sideMenu"
+    aria-controls="sideMenu"
+  >
+    ☰
+  </button>
+
+  <div
+    class="offcanvas offcanvas-start d-md-none"
+    tabindex="-1"
+    id="sideMenu"
+    aria-labelledby="sideMenuLabel"
+  >
+    <div class="offcanvas-header">
+
+      <button
+        type="button"
+        class="btn-close"
+        data-bs-dismiss="offcanvas"
+        aria-label="Close"
+      ></button>
+    </div>
+    <div class="offcanvas-body ">
       <app-side-menu [requests]="requests"></app-side-menu>
     </div>
-    <div class="col-10 col-md-7 m-auto mt-5 h-100">
+  </div>
+
+  <div class="row">
+
+    <div class="col-md-2 d-none d-md-block border-end min-vh-100 pt-5">
+      <app-side-menu [requests]="requests"></app-side-menu>
+    </div>
+
+  <div class="col-12 col-md-10 pt-3">
       <app-form-pane></app-form-pane>
     </div>
   </div>

--- a/lib/src/test-behaviours-ui/common/components/layout/layout.component.scss
+++ b/lib/src/test-behaviours-ui/common/components/layout/layout.component.scss
@@ -21,3 +21,4 @@
 .fixed-sidebar::-webkit-scrollbar-thumb {
   background-color: #495057; /* Thumb color */
 }
+

--- a/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.html
+++ b/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.html
@@ -1,5 +1,5 @@
 <div class="side-content text-black-50">
-  <h2>Requests</h2>
+    <h2 class="fs-3 fw-bold text-black pb-2 ">Requests</h2>
   <ul class="nav nav-pills flex-column mt-1">
     <li *ngFor="let request of requests ; let i = index">
       <button type="submit" class="nav-link text-black"
@@ -9,3 +9,9 @@
     </li>
   </ul>
 </div>
+
+
+
+
+
+ 

--- a/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.html
+++ b/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.html
@@ -1,14 +1,28 @@
+
 <div class="side-content text-black-50">
-    <h2 class="fs-3 fw-bold text-black pb-2 ">Requests</h2>
-  <ul class="nav nav-pills flex-column mt-1">
-    <li *ngFor="let request of requests ; let i = index">
-      <button type="submit" class="nav-link text-black"
-        (click)="setClickedRow(i)" [class.active]="i == selectedRow">{{
-        request.name }}</button>
+  <h2 class="fs-3 fw-bold text-black ">Requests</h2>
+  <ul class="nav nav-pills flex-column mt-4">
+    <li *ngFor="let request of requests; let i = index">
+      <button
+        type="button"
+        class="navlink text-start d-flex align-items-center justify-content-start gap-2   bg-transparent border-0 fw-bold p-2 rounded-2"
+        (click)="setClickedRow(i)"
+        [class.active]="i === selectedRow"
+      >
+        <span
+          class="fw-bold text-uppercase"
+          [ngClass]="getMethodClass(request.method)"
+          style="min-width: 50px"
+        >
+          {{ request.method }}
+        </span>
+        <span>{{ request.name }}</span>
+      </button>
       <hr class="text-black" />
     </li>
   </ul>
 </div>
+
 
 
 

--- a/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.html
+++ b/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.html
@@ -2,24 +2,26 @@
 <div class="side-content text-black-50">
   <h2 class="fs-3 fw-bold text-black ">Requests</h2>
   <ul class="nav nav-pills flex-column mt-4">
-    <li *ngFor="let request of requests; let i = index">
-      <button
-        type="button"
-        class="navlink text-start d-flex align-items-center justify-content-start gap-2   bg-transparent border-0 fw-bold p-2 rounded-2"
-        (click)="setClickedRow(i)"
-        [class.active]="i === selectedRow"
-      >
-        <span
-          class="fw-bold text-uppercase"
-          [ngClass]="getMethodClass(request.method)"
-          style="min-width: 50px"
-        >
-          {{ request.method }}
-        </span>
-        <span>{{ request.name }}</span>
-      </button>
-      <hr class="text-black" />
-    </li>
+<li *ngFor="let request of requests; let i = index">
+  <button
+    type="button"
+    class="navlink text-start d-flex align-items-center justify-content-start gap-2 bg-transparent border-0 fw-bold p-2 rounded-2"
+    (click)="setClickedRow(i)"
+    [class.active]="i === selectedRow"
+  >
+   
+    <span
+      class="fw-bold text-uppercase"
+      [ngClass]="getMethodClass(request.method)"
+    >
+      {{ request.method }}
+    </span>
+    
+    <span>{{ request.name }}</span>
+  </button>
+  <hr class="text-black" />
+</li>
+
   </ul>
 </div>
 

--- a/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.scss
+++ b/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.scss
@@ -11,3 +11,7 @@
    background-image: linear-gradient(to top, #F3482D, #F3482D);
   color: white;
 }
+
+.request__method{
+  min-width: 50px
+}

--- a/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.scss
+++ b/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.scss
@@ -1,1 +1,13 @@
+.navlink:focus,
+.navlink:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 2px #292a2b; 
+  background-image:  linear-gradient(to top, #F3482D, #F3482D);
+  color:white;
+  
+}
 
+.navlink.active {
+   background-image: linear-gradient(to top, #F3482D, #F3482D);
+  color: white#fff;
+}

--- a/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.scss
+++ b/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.scss
@@ -9,5 +9,5 @@
 
 .navlink.active {
    background-image: linear-gradient(to top, #F3482D, #F3482D);
-  color: white#fff;
+  color: white;
 }

--- a/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.ts
+++ b/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.ts
@@ -21,19 +21,22 @@ export class SideMenuComponent {
     };
   }
 
-  getMethodClass(method: string): string {
-    switch (method.toUpperCase()) {
-      case 'GET':
-        return 'text-success'; 
-      case 'POST':
-        return 'text-warning'; 
-      case 'PUT':
-        return 'text-primary'; 
-      case 'DELETE':
-        return 'text-danger'; 
-      default:
-        return 'text-secondary'; 
-    }
+getMethodClass(method: string): string {
+  switch (method.toUpperCase()) {
+    case 'GET':
+      return 'text-success';    
+    case 'POST':
+      return 'text-warning';    
+    case 'PUT':
+      return 'text-primary';    
+    case 'PATCH':
+      return 'text-info';      
+    case 'DELETE':
+      return 'text-danger';     
+    default:
+      return 'text-secondary'; 
   }
+}
+
 }
 

--- a/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.ts
+++ b/lib/src/test-behaviours-ui/common/components/side-menu/side-menu.component.ts
@@ -1,6 +1,9 @@
+
+
 import { Component, Input } from '@angular/core';
 import { Request } from '../layout/layout.component';
 import { DataService } from '../../../../../src/test-behaviours-core/services/data-services/data.service';
+
 @Component({
   selector: 'app-side-menu',
   templateUrl: './side-menu.component.html',
@@ -10,10 +13,27 @@ export class SideMenuComponent {
   @Input() requests!: Request[];
   setClickedRow: Function;
   selectedRow!: Number;
+
   constructor(private dataService: DataService) {
-    this.setClickedRow = function (index: any) {
+    this.setClickedRow = (index: any) => {
       this.selectedRow = index;
       this.dataService.setSharedData(this.requests[index]);
     };
   }
+
+  getMethodClass(method: string): string {
+    switch (method.toUpperCase()) {
+      case 'GET':
+        return 'text-success'; 
+      case 'POST':
+        return 'text-warning'; 
+      case 'PUT':
+        return 'text-primary'; 
+      case 'DELETE':
+        return 'text-danger'; 
+      default:
+        return 'text-secondary'; 
+    }
+  }
 }
+

--- a/lib/src/test-behaviours-ui/test-behaviours-ui.module.ts
+++ b/lib/src/test-behaviours-ui/test-behaviours-ui.module.ts
@@ -5,6 +5,7 @@ import { FormPaneComponent } from './common/components/form-pane/form-pane.compo
 import { DropDownDirective } from './common/directives/drop-down.directive';
 import { LayoutComponent } from './common/components/layout/layout.component';
 import { JsonTextAreaComponent } from './common/components/json-text-area/json-text-area.component';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
@@ -16,6 +17,7 @@ import { JsonTextAreaComponent } from './common/components/json-text-area/json-t
   ],
   imports: [
     CommonModule,
+    FormsModule,
   ],
   exports: [LayoutComponent],
  })

--- a/package-lock.json
+++ b/package-lock.json
@@ -3017,16 +3017,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@schematics/angular": {
       "version": "16.1.5",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.1.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3017,6 +3017,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@schematics/angular": {
       "version": "16.1.5",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.1.5.tgz",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { HeaderComponent } from './header/header.component';
   declarations: [
     AppComponent,
     HeaderComponent,
+  
   ],
   imports: [
     BrowserModule,

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,9 +1,33 @@
-<nav class="navbar bg-dark fixed-header">
-  <div class="container-fluid">
-    <a class="navbar-brand w-25 m-auto responsive-logo" href="#">
-      <img src="assets/images/logo.png" alt="Logo" class="d-inline-block align-text-top">
+
+
+<nav class="navbar navbar-dark bg-dark fixed-header py-2 ">
+  <div class="container-fluid d-flex align-items-center justify-content-between px-2">
+  
+    <button
+      class="btn btn__color btn-outline-dark d-lg-none bg-black text-white m-0 "
+      type="button"
+      data-bs-toggle="offcanvas"
+      data-bs-target="#sideMenu"
+      aria-controls="sideMenu"
+    >
+      ☰
+    </button>
+
+    <a class="navbar-brand mx-auto mx-md-0" href="#">
+      <img src="assets/images/logo.png" alt="Logo" class="d-inline-block align-text-top" height="30">
     </a>
-    <a [href]="fileUrl" (click)="export()" download="file.json"
-      class="btn btn-primary ">export</a>
+
+    
+    <div class="ms-auto d-none d-sm-block">
+      <a [href]="fileUrl" (click)="export()" download="file.json"
+        class="btn text-white export__btn fw-medium">Export</a>
+    </div>
+
+
+    <div class="d-sm-none">
+      <a [href]="fileUrl" (click)="export()" download="file.json"
+        class="btn btn-sm export__btn text-white fw-medium">Export</a>
+    </div>
+
   </div>
 </nav>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,7 +1,7 @@
 <nav class="navbar bg-dark fixed-header">
   <div class="container-fluid">
-    <a class="navbar-brand w-25 m-auto" href="#">
-      <img src="assets/images/logo.png" alt="Logo" class="d-inline-block align-text-top w-50">
+    <a class="navbar-brand w-25 m-auto responsive-logo" href="#">
+      <img src="assets/images/logo.png" alt="Logo" class="d-inline-block align-text-top">
     </a>
     <a [href]="fileUrl" (click)="export()" download="file.json"
       class="btn btn-primary ">export</a>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -1,3 +1,4 @@
+
 .fixed-header{
   position: fixed;
       top: 0;
@@ -6,12 +7,41 @@
       height: 60px;
 }
 
+.export__btn {
+
+  background-image:  linear-gradient(to top, #EB3349, #F45C43);;
+  border: solid transparent 2px;
+  box-shadow: 1px 1px 1px rgb(12, 12, 12);
+}
+.btn__color{
+  background-image:  linear-gradient(to top, #EB3349, #F45C43);;
+  border: solid transparent 2px;
+}
+
+
 .responsive-logo img {
   width: 100%;
 }
 
+.navbar .btn-outline-light {
+  background-color: transparent;
+  border: none;
+  font-size: 1.5rem;
+}
+
+
 @media (min-width: 768px) {
   .responsive-logo img {
     width: 50%;
+  }
+}
+
+@media (max-width: 320px) {
+  .navbar-brand img {
+    height: 25px; 
+  }
+  .export__btn {
+    font-size: 12px;
+    padding: 4px 8px;
   }
 }

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -6,3 +6,12 @@
       height: 60px;
 }
 
+.responsive-logo img {
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .responsive-logo img {
+    width: 50%;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,3 +4,4 @@ body {
   background: linear-gradient(to bottom, #fef7ed, #feefee);
   height: 100%;
 }
+


### PR DESCRIPTION
I created a responsive page.

I implemented a responsive sidebar using Bootstrap's offcanvas component.

On small screens, a toggle button (☰) appears to open and close the side menu.

On medium and larger screens, the side menu remains visible as a fixed column.

Fixed Navbar Positioning:

I adjusted the layout so that the navbar appears above the sidebar, instead of overlapping it.

I added proper spacing (padding-top) to avoid content being hidden behind the fixed navbar.

Responsive Logo Size:

The logo inside the navbar is now responsive.

On small screens (mobile), it takes 100% width.

On larger screens, it shrinks to 50% width.

This was done using custom CSS with media queries and used BEM style.

I enhanced the UI of the Behavior page by adding some styling and layout adjustments.

Bootstrap JavaScript Functionality:

I ensured that Bootstrap's JavaScript (especially for offcanvas) is working correctly by adding bootstrap.bundle.min.js to the angular.json file under the "scripts" section.

General Layout Enhancements:

The layout was improved using Bootstrap’s grid system to ensure proper alignment and responsiveness across all screen sizes.

